### PR TITLE
Fix auto-merge workflow: add missing checkout step

### DIFF
--- a/.github/workflows/auto-merge-docs.yml
+++ b/.github/workflows/auto-merge-docs.yml
@@ -18,6 +18,9 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
       - name: Enforce allowlist and path-only change
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
Fixes the "not a git repository" error in the auto-merge workflow.

## 🐛 Problem
The auto-merge workflow was failing with:


## ✅ Solution  
Add the missing `actions/checkout@v4` step as the first step in the workflow.

## 📝 Changes
- Add `actions/checkout@v4` before any other steps
- This ensures the repository is properly checked out before git operations
- Required for the `peter-evans/enable-pull-request-automerge` action to work

## 🧪 Impact
After this fix, documentation PRs from trusted users will auto-merge correctly.