### PR TITLE
Complete auto-merge workflow fix: handle detached HEAD state

### DIFF
--- a/.github/workflows/auto-merge-docs.yml
+++ b/.github/workflows/auto-merge-docs.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
         
       - name: Enforce allowlist and path-only change
         uses: actions/github-script@v7
@@ -67,6 +69,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           merge-method: squash
+          pull-request-number: ${{ github.event.pull_request.number }}
           
       - name: Add auto-merge label
         uses: actions/github-script@v7


### PR DESCRIPTION
This PR completes the auto-merge workflow fix by addressing the "not on any branch" error.

## 🐛 Problem  
After the initial checkout fix was merged, the auto-merge workflow was still failing with:
```
could not determine current branch: failed to run git: not on any branch
```

## ✅ Solution
Add the missing parameters that handle the detached HEAD state common in GitHub Actions PR workflows:

### Changes Made:
1. **Explicit token in checkout**: Ensures proper authentication
   ```yaml
   - name: Checkout repository
     uses: actions/checkout@v4
     with:
       token: ${{ secrets.GITHUB_TOKEN }}
   ```

2. **Pull request number parameter**: Explicitly tells the action which PR to enable auto-merge for
   ```yaml
   - name: Enable auto-merge
     uses: peter-evans/enable-pull-request-automerge@v3
     with:
       token: ${{ secrets.GITHUB_TOKEN }}
       merge-method: squash
       pull-request-number: ${{ github.event.pull_request.number }}
   ```

## 🎯 Impact
After this fix, documentation PRs from trusted users (`gmondello`) will successfully auto-merge without the detached HEAD errors.

## 🔍 Context
These were the missing pieces from the previous fix attempt that got cut off when PR #5 was merged before the complete solution was pushed.