### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cost-center-sync-cached.yml
+++ b/.github/workflows/cost-center-sync-cached.yml
@@ -20,6 +20,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   sync-cost-centers:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/github/cost-center-automation/security/code-scanning/4](https://github.com/github/cost-center-automation/security/code-scanning/4)

To fix this issue according to least privilege, add a `permissions` key near the top level of the workflow YAML file (immediately after the `name` or `on` block), specifying the minimal permissions needed for the jobs to complete. For the shown workflow, only reading repository contents and default permissions for uploading artifacts are generally required (`contents: read`). You can further tune the permissions if you know a job requires additional permissions. This change will ensure that the GITHUB_TOKEN used in the jobs has only the access it truly needs.  
**How to change:**  
- Insert a `permissions:` block at the root of `.github/workflows/cost-center-sync-cached.yml` after the `name` or after the `on` key.
- The minimal block to add is:
  ```yaml
  permissions:
    contents: read
  ```
- No other YAML regions or steps need to change for this improvement.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
